### PR TITLE
fix missig lib/utils.ts

### DIFF
--- a/ui/lib/utils.ts
+++ b/ui/lib/utils.ts
@@ -1,0 +1,3 @@
+// ui/lib/utils.ts
+import classNames from 'classnames';
+export { classNames as cn };

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -14,6 +14,7 @@
         "@radix-ui/react-slot": "^1.1.0",
         "@radix-ui/react-tooltip": "^1.1.3",
         "class-variance-authority": "^0.7.0",
+        "classnames": "^2.5.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.447.0",
         "next": "14.2.14",
@@ -1914,6 +1915,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
     },
     "node_modules/client-only": {
       "version": "0.0.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -15,6 +15,7 @@
     "@radix-ui/react-slot": "^1.1.0",
     "@radix-ui/react-tooltip": "^1.1.3",
     "class-variance-authority": "^0.7.0",
+    "classnames": "^2.5.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.447.0",
     "next": "14.2.14",


### PR DESCRIPTION
added `lib/config.ts` to fix this broken import:

https://github.com/xjdr-alt/entropix/blob/b085381ae73e3de6919c8bfb1825a289583e66e9/ui/components/ui/drawer.tsx#L6

maybe this wasn't pushed, because `lib/` is gitignored?