### PR TITLE
Bugfix to varentropy calculation 

### DIFF
--- a/entropix/sampler.py
+++ b/entropix/sampler.py
@@ -47,7 +47,7 @@ def calculate_metrics(logits: jnp.ndarray, attention_scores: jnp.ndarray) -> Dic
 
     attention_probs = jax.nn.softmax(attention_scores, axis=-1)
     attn_entropy = -jnp.sum(attention_probs * jnp.log2(jnp.clip(attention_probs, 1e-10, 1.0)), axis=-1)
-    attn_varentropy = jnp.var(attn_entropy, axis=-1)
+    attn_varentropy = jnp.var(attn_entropy, axis=1)
 
     mean_attention = jnp.mean(attention_probs, axis=1)
     agreement = jnp.mean(jnp.abs(attention_probs - mean_attention[:, None, :]), axis=(1, 2))

--- a/entropix/torch_main.py
+++ b/entropix/torch_main.py
@@ -90,7 +90,7 @@ def main():
       gen_tokens = next_token
       print(tokenizer.decode([next_token.item()]), end='', flush=True)
       cur_pos = seqlen
-      stop = torch.tensor([128001, 128008, 128009])
+      stop = torch.tensor([128001, 128008, 128009]).to(DEVICE)
       while cur_pos < 8192:
         cur_pos += 1
         logits, kvcache, scores, stats = xfmr(xfmr_weights, model_params, next_token, cur_pos, freqs_cis[cur_pos:cur_pos+1], kvcache)

--- a/entropix/torch_main.py
+++ b/entropix/torch_main.py
@@ -17,6 +17,8 @@ from entropix.torch_weights import XfmrWeights, LayerWeights, load_weights
 from entropix.torch_sampler import sample
 from entropix.prompts import prompt, bp1
 
+DEVICE = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+
 
 def apply_scaling(freqs: torch.Tensor):
     # Values obtained from grid search
@@ -52,7 +54,7 @@ def precompute_freqs_cis(
         freqs = apply_scaling(freqs)
     freqs = torch.outer(t, freqs)
     freqs_cis = torch.polar(torch.ones_like(freqs), freqs)  # complex64
-    return freqs_cis
+    return freqs_cis.to(DEVICE)
 
 
 def build_attn_mask(seqlen: int, start_pos: int) -> torch.Tensor:
@@ -61,7 +63,7 @@ def build_attn_mask(seqlen: int, start_pos: int) -> torch.Tensor:
       mask = torch.full((seqlen, seqlen), float("-inf"))
       mask = torch.triu(mask, diagonal=1)
       mask = torch.hstack([torch.zeros((seqlen, start_pos)), mask]).to(torch.bfloat16)
-  return mask
+  return mask.to(DEVICE)
 
 
 def main():
@@ -82,7 +84,7 @@ def main():
       bsz, seqlen = tokens.shape
       attn_mask = build_attn_mask(seqlen, cur_pos)
       freqs_cis = precompute_freqs_cis(model_params.head_dim, model_params.max_seq_len, model_params.rope_theta, model_params.use_scaled_rope)
-      kvcache = KVCache.new(model_params.n_layers, bsz, model_params.max_seq_len, model_params.n_local_kv_heads, model_params.head_dim)
+      kvcache = KVCache.new(model_params.n_layers, bsz, model_params.max_seq_len, model_params.n_local_kv_heads, model_params.head_dim).to(DEVICE)
       logits, kvcache, _, _ = xfmr(xfmr_weights, model_params, tokens, cur_pos, freqs_cis[:seqlen], kvcache, attn_mask=attn_mask)
       next_token = torch.argmax(logits[:, -1], dim=-1, keepdim=True).to(torch.long)
       gen_tokens = next_token

--- a/entropix/torch_sampler.py
+++ b/entropix/torch_sampler.py
@@ -60,7 +60,7 @@ def calculate_metrics(logits: torch.Tensor, attention_scores: torch.Tensor) -> D
 
     attention_probs = F.softmax(attention_scores, dim=-1)
     attn_entropy = -torch.sum(attention_probs * torch.log2(torch.clamp(attention_probs, 1e-10, 1.0)), dim=-1)
-    attn_varentropy = torch.var(attn_entropy, dim=-1)
+    attn_varentropy = torch.var(attn_entropy, dim=1)
 
     mean_attention = torch.mean(attention_probs, dim=1)
     agreement = torch.mean(torch.abs(attention_probs - mean_attention.unsqueeze(1)), dim=(1, 2))


### PR DESCRIPTION
This PR does 2 things:
1) Adds dynamic torch device support (similar to #https://github.com/xjdr-alt/entropix/pull/3) but with the device logic only being handled in `torch_main.py`
2) More importantly, it fixes variance of attention entropy calculation (see below)

In `calculate_metrics()`, `attn_entropy` is of shape `(bs, heads,1)`. The variance computation is happening over `axix/dim = -1` which means its computing the variance over a single element which I'm guessing is unintended behaviour. 

`jnp.var` over a single item returns 0 so this basically means that `attn_varentropy` has no effect on `adaptive_sample`

The torch parts have a bigger problem. `torch.var` over a single item returns `nan` so `temperature` and `top p` are both `nan`. This means that the entire logit tensor is `nans`. Ordinarily, `torch.multinomial` cannot sample over a tensor with `nan` but `_sample` has a check for nans and fills them which means that in this case the tensor is a constant tensor so the sampling would be completely random 

The fix is pretty straightforward, compute the variance over the head dimension `dim = 1` instead (which I assume is the intended call).