### PR TITLE
Fix import issue for @/lib/utils in frontend

### DIFF
--- a/ui/components.json
+++ b/ui/components.json
@@ -12,7 +12,7 @@
   },
   "aliases": {
     "components": "@/components",
-    "utils": "@/lib/utils",
+    "utils": "@/library/utils",
     "ui": "@/components/ui",
     "lib": "@/lib",
     "hooks": "@/hooks"

--- a/ui/components/Artifacts/Logs.tsx
+++ b/ui/components/Artifacts/Logs.tsx
@@ -4,7 +4,7 @@ import React, { useEffect, useRef, useState, useCallback, memo } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { ChevronRightIcon} from "lucide-react"
-import { cn } from "@/lib/utils"
+import { cn } from "@/library/utils"
 
 interface OutputEntry {
   id: string

--- a/ui/components/Artifacts/Tabs.tsx
+++ b/ui/components/Artifacts/Tabs.tsx
@@ -3,7 +3,7 @@ import { motion } from 'framer-motion';
 import { Globe, Terminal } from 'lucide-react';
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Button } from "@/components/ui/button";
-import { cn } from '@/lib/utils';
+import { cn } from '@/library/utils';
 
 interface TabsProps {
   artifacts: ArtifactContent[];

--- a/ui/components/ui/avatar.tsx
+++ b/ui/components/ui/avatar.tsx
@@ -3,7 +3,7 @@
 import * as React from "react"
 import * as AvatarPrimitive from "@radix-ui/react-avatar"
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/library/utils"
 
 const Avatar = React.forwardRef<
   React.ElementRef<typeof AvatarPrimitive.Root>,

--- a/ui/components/ui/badge.tsx
+++ b/ui/components/ui/badge.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import { cva, type VariantProps } from "class-variance-authority"
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/library/utils"
 
 const badgeVariants = cva(
   "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",

--- a/ui/components/ui/button.tsx
+++ b/ui/components/ui/button.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
 import { cva, type VariantProps } from "class-variance-authority"
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/library/utils"
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",

--- a/ui/components/ui/card.tsx
+++ b/ui/components/ui/card.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/library/utils"
 
 const Card = React.forwardRef<
   HTMLDivElement,

--- a/ui/components/ui/dialog.tsx
+++ b/ui/components/ui/dialog.tsx
@@ -4,7 +4,7 @@ import * as React from "react"
 import * as DialogPrimitive from "@radix-ui/react-dialog"
 import { X } from "lucide-react"
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/library/utils"
 
 const Dialog = DialogPrimitive.Root
 

--- a/ui/components/ui/dropdown-menu.tsx
+++ b/ui/components/ui/dropdown-menu.tsx
@@ -4,7 +4,7 @@ import * as React from "react"
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
 import { Check, ChevronRight, Circle } from "lucide-react"
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/library/utils"
 
 const DropdownMenu = DropdownMenuPrimitive.Root
 

--- a/ui/components/ui/input.tsx
+++ b/ui/components/ui/input.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/library/utils"
 
 export interface InputProps
   extends React.InputHTMLAttributes<HTMLInputElement> {}

--- a/ui/components/ui/label.tsx
+++ b/ui/components/ui/label.tsx
@@ -4,7 +4,7 @@ import * as React from "react"
 import * as LabelPrimitive from "@radix-ui/react-label"
 import { cva, type VariantProps } from "class-variance-authority"
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/library/utils"
 
 const labelVariants = cva(
   "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"

--- a/ui/components/ui/scroll-area.tsx
+++ b/ui/components/ui/scroll-area.tsx
@@ -3,7 +3,7 @@
 import * as React from "react"
 import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area"
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/library/utils"
 
 const ScrollArea = React.forwardRef<
   React.ElementRef<typeof ScrollAreaPrimitive.Root>,

--- a/ui/components/ui/separator.tsx
+++ b/ui/components/ui/separator.tsx
@@ -3,7 +3,7 @@
 import * as React from "react"
 import * as SeparatorPrimitive from "@radix-ui/react-separator"
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/library/utils"
 
 const Separator = React.forwardRef<
   React.ElementRef<typeof SeparatorPrimitive.Root>,

--- a/ui/components/ui/skeleton.tsx
+++ b/ui/components/ui/skeleton.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@/lib/utils"
+import { cn } from "@/library/utils"
 
 function Skeleton({
   className,

--- a/ui/components/ui/slider.tsx
+++ b/ui/components/ui/slider.tsx
@@ -3,7 +3,7 @@
 import * as React from "react"
 import * as SliderPrimitive from "@radix-ui/react-slider"
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/library/utils"
 
 const Slider = React.forwardRef<
   React.ElementRef<typeof SliderPrimitive.Root>,

--- a/ui/components/ui/switch.tsx
+++ b/ui/components/ui/switch.tsx
@@ -3,7 +3,7 @@
 import * as React from "react"
 import * as SwitchPrimitives from "@radix-ui/react-switch"
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/library/utils"
 
 const Switch = React.forwardRef<
   React.ElementRef<typeof SwitchPrimitives.Root>,

--- a/ui/components/ui/tabs.tsx
+++ b/ui/components/ui/tabs.tsx
@@ -3,7 +3,7 @@
 import * as React from "react"
 import * as TabsPrimitive from "@radix-ui/react-tabs"
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/library/utils"
 
 const Tabs = TabsPrimitive.Root
 

--- a/ui/components/ui/textarea.tsx
+++ b/ui/components/ui/textarea.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/library/utils"
 
 export interface TextareaProps
   extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}

--- a/ui/components/ui/toggle.tsx
+++ b/ui/components/ui/toggle.tsx
@@ -4,7 +4,7 @@ import * as React from "react"
 import * as TogglePrimitive from "@radix-ui/react-toggle"
 import { cva, type VariantProps } from "class-variance-authority"
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/library/utils"
 
 const toggleVariants = cva(
   "inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors hover:bg-muted hover:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground",

--- a/ui/components/ui/tooltip.tsx
+++ b/ui/components/ui/tooltip.tsx
@@ -3,7 +3,7 @@
 import * as React from "react"
 import * as TooltipPrimitive from "@radix-ui/react-tooltip"
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/library/utils"
 
 const TooltipProvider = TooltipPrimitive.Provider
 

--- a/ui/library/utils.ts
+++ b/ui/library/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+export function cn(...inputs: ClassValue[]) {
+    return twMerge(clsx(inputs))
+}


### PR DESCRIPTION
Problem
The frontend was encountering runtime errors due to missing imports from @/lib/utils. The problem was from the root .gitignore including "/lib" which was probably not meant for the frontend directory, so the frontend's lib folder wasn't tracked.

Solution
I've added the folder "library" (instead of "lib" so the root gitignore doesn't interfere with the frontend files) and added utils.ts that folder.

Changes made
Added library/utils.ts, and replaced all @/lib/utils imports with @/library/utils

Testing
I've tested these changes locally and confirmed that:

The build process completes without errors.
Imports using @/library/utils now work correctly.
Git is tracking the utils.ts file as expected.