### PR TITLE
Update README.md with proper tokenizer.model download

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ poetry run python download_weights.py --model-id meta-llama/Llama-3.2-1B-Instruc
 download tokenizer.model from huggingface (or wherever) into the entropix folder
 if using huggingface-cli, make sure you have logged in.
 ```bash
-poetry run huggingface-cli download meta-llama/Meta-Llama-3.1-8B-Instruct --include "original/tokenizer.model" --local-dir entropix/tokenizer.model
+poetry run bash -c "huggingface-cli download meta-llama/Llama-3.2-1B-Instruct original/tokenizer.model --local-dir entropix && mv entropix/original/tokenizer.model entropix/ && rmdir entropix/original"
 ```
 
 run it


### PR DESCRIPTION
The existing command to download tokenizer.model pulls from 3.1-8B instead of 3.2-1B; since 3.1 and 3.2 require different license agreements, this is an unnecessary complication. Additionally, the original command downloads the file to ./entropix/original/tokenizer.model instead of ./entropix/tokenizer.model.

This change pulls tokenizer.mode from 3.2-1B, moves the file to the correct location and deletes the now-empty entropix/original folder.