### PR TITLE
Make compare_outputs more flexible

### DIFF
--- a/entropix/torch_weights.py
+++ b/entropix/torch_weights.py
@@ -6,8 +6,6 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
-import ml_dtypes
-
 from pathlib import Path
 
 class LayerWeights(NamedTuple):
@@ -28,8 +26,8 @@ class XfmrWeights(NamedTuple):
   layer_weights: List[LayerWeights]
 
 def compare_outputs(torch_output: torch.Tensor, jax_output: jax.Array, atol: float = 1e-5, rtol: float = 1e-8) -> None:
-  jax_output_np = np.array(jax_output)
-  torch_output_np = torch_output.cpu().view(dtype=torch.uint16).numpy().view(ml_dtypes.bfloat16)
+  jax_output_np = np.array(jax_output).astype(np.float32)
+  torch_output_np = torch_output.cpu().float().numpy()
 
   try:
     np.testing.assert_allclose(torch_output_np, jax_output_np, atol=atol, rtol=rtol)


### PR DESCRIPTION
I'm working with ROCm, and I believe due to the version of JAX available being 0.4.30, the compare_outputs function gives error: "numpy.exceptions.DTypePromotionError: The DTypes <class 'numpy.dtypes.Float16DType'> and <class 'numpy.dtype[bfloat16]'> do not have a common DType. For example they cannot be stored in a single array unless the dtype is `object`."

This change works with ROCm, and while I can't test it, it should work fine with CUDA / latest JAX. Unless I've misunderstood the intent of compare_outputs (ensure cast to bfloat16 didn't change things too much), this should serve the same purpose but be more flexible.