### PR TITLE
Df/get torch device

### DIFF
--- a/entropix/torch_device.py
+++ b/entropix/torch_device.py
@@ -1,0 +1,10 @@
+import torch
+
+def get_device():
+    if torch.backends.mps.is_available():
+        device = torch.device("mps")
+    elif torch.cuda.is_available():
+        device = torch.device("cuda")
+    else:
+        device = torch.device("cpu")
+    return device

--- a/entropix/torch_kvcache.py
+++ b/entropix/torch_kvcache.py
@@ -1,13 +1,8 @@
 import torch
 import torch.nn as nn
 
-# Device selection, tree is like first apple silicion, then cuda, fallback is cpu.
-if torch.backends.mps.is_available():
-    device = torch.device("mps")
-elif torch.cuda.is_available():
-    device = torch.device("cuda")
-else:
-    device = torch.device("cpu")
+from entropix.torch_device import get_device
+device = get_device
 
 #print(f"Using device: {device}")
 

--- a/entropix/torch_main.py
+++ b/entropix/torch_main.py
@@ -18,6 +18,7 @@ from entropix.torch_sampler import sample
 from entropix.prompts import prompt, bp1
 
 from entropix.torch_device import get_device
+
 device = get_device
 
 print(f"Using device: {device}")

--- a/entropix/torch_main.py
+++ b/entropix/torch_main.py
@@ -17,14 +17,8 @@ from entropix.torch_weights import XfmrWeights, LayerWeights, load_weights
 from entropix.torch_sampler import sample
 from entropix.prompts import prompt, bp1
 
-
-# Device selection, tree is like first apple silicion, then cuda, fallback is cpu.
-if torch.backends.mps.is_available():
-    device = torch.device("mps")
-elif torch.cuda.is_available():
-    device = torch.device("cuda")
-else:
-    device = torch.device("cpu")
+from entropix.torch_device import get_device
+device = get_device
 
 print(f"Using device: {device}")
 

--- a/entropix/torch_main.py
+++ b/entropix/torch_main.py
@@ -17,8 +17,6 @@ from entropix.torch_weights import XfmrWeights, LayerWeights, load_weights
 from entropix.torch_sampler import sample
 from entropix.prompts import prompt, bp1
 
-DEVICE = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
-
 
 # Device selection, tree is like first apple silicion, then cuda, fallback is cpu.
 if torch.backends.mps.is_available():
@@ -107,7 +105,7 @@ def main():
       bsz, seqlen = tokens.shape
       attn_mask = build_attn_mask(seqlen, cur_pos)
       freqs_cis = precompute_freqs_cis(model_params.head_dim, model_params.max_seq_len, model_params.rope_theta, model_params.use_scaled_rope)
-      kvcache = KVCache.new(model_params.n_layers, bsz, model_params.max_seq_len, model_params.n_local_kv_heads, model_params.head_dim).to(DEVICE)
+      kvcache = KVCache.new(model_params.n_layers, bsz, model_params.max_seq_len, model_params.n_local_kv_heads, model_params.head_dim).to(device)
       logits, kvcache, _, _ = xfmr(xfmr_weights, model_params, tokens, cur_pos, freqs_cis[:seqlen], kvcache, attn_mask=attn_mask)
       next_token = torch.argmax(logits[:, -1], dim=-1, keepdim=True).to(torch.int32)
       gen_tokens = next_token

--- a/entropix/torch_model.py
+++ b/entropix/torch_model.py
@@ -10,13 +10,8 @@ from entropix.torch_stats import AttnStats
 
 DEFAULT_MASK_VALUE = -0.7 * float(torch.finfo(torch.float32).max)
 
-# Device selection, tree is like first apple silicion, then cuda, fallback is cpu.
-if torch.backends.mps.is_available():
-    device = torch.device("mps")
-elif torch.cuda.is_available():
-    device = torch.device("cuda")
-else:
-    device = torch.device("cpu")
+from entropix.torch_device import get_device
+device = get_device
 
 #print(f"Using device: {device}")
 

--- a/entropix/torch_sampler.py
+++ b/entropix/torch_sampler.py
@@ -2,13 +2,8 @@ import torch
 import torch.nn.functional as F
 from typing import Tuple, Dict
 
-# Device selection, tree is like first apple silicion, then cuda, fallback is cpu.
-if torch.backends.mps.is_available():
-    device = torch.device("mps")
-elif torch.cuda.is_available():
-    device = torch.device("cuda")
-else:
-    device = torch.device("cpu")
+from entropix.torch_device import get_device
+device = get_device
 
 LN_2 = 0.69314718056  # ln(2) = 1.0 / LOG2_E
 

--- a/entropix/torch_stats.py
+++ b/entropix/torch_stats.py
@@ -1,12 +1,7 @@
 import torch
 
-# Device selection, tree is like first apple silicion, then cuda, fallback is cpu.
-if torch.backends.mps.is_available():
-    device = torch.device("mps")
-elif torch.cuda.is_available():
-    device = torch.device("cuda")
-else:
-    device = torch.device("cpu")
+from entropix.torch_device import get_device
+device = get_device
 
 #print(f"Using device: {device}")
 

--- a/entropix/torch_weights.py
+++ b/entropix/torch_weights.py
@@ -10,13 +10,8 @@ import ml_dtypes
 
 from pathlib import Path
 
-# Device selection, tree is like first apple silicion, then cuda, fallback is cpu.
-if torch.backends.mps.is_available():
-    device = torch.device("mps")
-elif torch.cuda.is_available():
-    device = torch.device("cuda")
-else:
-    device = torch.device("cpu")
+from entropix.torch_device import get_device
+device = get_device
 
 #print(f"Using device: {device}")
 


### PR DESCRIPTION
Bug: device not set correctly, some tensors on `cpu` while the rest are successfully on `mps`.

```RuntimeError: Placeholder storage has not been allocated on MPS device!```

The device logic was duplicated across several files, so it was easy to miss the one line where this happened. I've moved that logic into a function in `torch_device.py`.