### PR TITLE
(closes #43) Remove pytorch source from project direct reference torch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ pydantic = "^2.9.2"
 blobfile = "^3.0.0"
 ml-dtypes = "^0.5.0"
 rich = "^13.8.1"
-torch = {version = "^2.4.1", source = "pytorch", extras = ["+cu124"], optional = true, markers = "platform_system != 'Darwin'"}
+torch = {version = "^2.4.1", extras = ["+cu124"], optional = true, markers = "platform_system != 'Darwin'"}
 chex = "^0.1.87"
 tyro = "^0.8.11"
 
@@ -31,11 +31,6 @@ huggingface-hub = {extras = ["cli"], version = "^0.25.1"}
 torch = "^2.4.1"
 fairscale = "^0.4.13"
 
-
-[[tool.poetry.source]]
-name = "pytorch"
-url = "https://download.pytorch.org/whl/cu124"
-priority = "explicit"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
Remove pytorch source from project keeping the extra settings for OS and Version. Fixes issue #43 

![resim](https://github.com/user-attachments/assets/dbc9532e-6558-47fc-b2c3-85bbc57205a4)
