### PR TITLE
#43: Fix pytorch install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ ml-dtypes = "^0.5.0"
 rich = "^13.8.1"
 torch = [
     {version = "^2.4.1+cu124", source = "pytorch", markers = "platform_machine != 'Darwin'"},
-    {version = "^2.4.1", source = "pytorch", markers = "platform_machine != 'Darwin'"}
+    {version = "^2.4.1", source = "pytorch"}
 ]
 chex = "^0.1.87"
 tyro = "^0.8.11"


### PR DESCRIPTION
Allows install of either pytorch w/ cuda or plain pytorch and also fixes this error:
```
$ poetry lock && poetry install
Installing dependencies from lock file

Repository "pytorch" does not exist.
```