### PR TITLE
Bugfixes surrounding torch dtypes and QOL updates for torch

### DIFF
--- a/entropix/torch_kvcache.py
+++ b/entropix/torch_kvcache.py
@@ -12,8 +12,8 @@ else:
 #print(f"Using device: {device}")
 
 class KVCache(nn.Module):
-    def init(self, layers: int, bsz: int, max_seq_len: int, kv_heads: int, head_dim: int):
-        super(KVCache, self).init()
+    def __init__(self, layers: int, bsz: int, max_seq_len: int, kv_heads: int, head_dim: int):
+        super(KVCache, self).__init__()
         # Initialize k and v as buffers to ensure they're part of the module state
         self.register_buffer(
             'k',
@@ -63,7 +63,6 @@ class KVCache(nn.Module):
 
         # Update the k and v tensors in the specified layer and position
         bsz, insert_len, _, _ = xk.shape  # Assuming xk shape is (bsz, insert_len, kv_heads, head_dim)
-        expected_dtype = xk.dtype
         self.k[layer_idx, :bsz, cur_pos:cur_pos+insert_len, :, :] = xk
         self.v[layer_idx, :bsz, cur_pos:cur_pos+insert_len, :, :] = xv
 
@@ -75,8 +74,8 @@ class KVCache(nn.Module):
             # Otherwise, repeat the existing keys and values from the cache
             keys = self.k[layer_idx].repeat_interleave(n_rep, dim=2)
             values = self.v[layer_idx].repeat_interleave(n_rep, dim=2)
-        keys = keys[: bsz].to(expected_dtype)
-        values = values[: bsz].to(expected_dtype)
+        keys = keys[: bsz].to(xk.dtype)
+        values = values[: bsz].to(xv.dtype)
         return keys, values, self
 
     def clear(self):

--- a/entropix/torch_kvcache.py
+++ b/entropix/torch_kvcache.py
@@ -12,8 +12,8 @@ else:
 #print(f"Using device: {device}")
 
 class KVCache(nn.Module):
-    def __init__(self, layers: int, bsz: int, max_seq_len: int, kv_heads: int, head_dim: int):
-        super(KVCache, self).__init__()
+    def init(self, layers: int, bsz: int, max_seq_len: int, kv_heads: int, head_dim: int):
+        super(KVCache, self).init()
         # Initialize k and v as buffers to ensure they're part of the module state
         self.register_buffer(
             'k',
@@ -60,14 +60,12 @@ class KVCache(nn.Module):
                 - keys: Updated or repeated keys tensor.
                 - values: Updated or repeated values tensor.
         """
-        # Ensure xk and xv have the correct device and dtype
-        xk = xk.to(self.k.dtype)
-        xv = xv.to(self.v.dtype)
 
         # Update the k and v tensors in the specified layer and position
-        insert_len = xk.size(1)  # Assuming xk shape is (bsz, insert_len, kv_heads, head_dim)
-        self.k[layer_idx, :, cur_pos:cur_pos+insert_len, :, :] = xk
-        self.v[layer_idx, :, cur_pos:cur_pos+insert_len, :, :] = xv
+        bsz, insert_len, _, _ = xk.shape  # Assuming xk shape is (bsz, insert_len, kv_heads, head_dim)
+        expected_dtype = xk.dtype
+        self.k[layer_idx, :bsz, cur_pos:cur_pos+insert_len, :, :] = xk
+        self.v[layer_idx, :bsz, cur_pos:cur_pos+insert_len, :, :] = xv
 
         if cur_pos == 0:
             # If inserting at the beginning, repeat the new keys and values
@@ -77,7 +75,8 @@ class KVCache(nn.Module):
             # Otherwise, repeat the existing keys and values from the cache
             keys = self.k[layer_idx].repeat_interleave(n_rep, dim=2)
             values = self.v[layer_idx].repeat_interleave(n_rep, dim=2)
-
+        keys = keys[: bsz].to(expected_dtype)
+        values = values[: bsz].to(expected_dtype)
         return keys, values, self
 
     def clear(self):

--- a/entropix/torch_main.py
+++ b/entropix/torch_main.py
@@ -1,8 +1,5 @@
 import torch
-
-
 import tyro
-
 from pathlib import Path
 
 from entropix.config import LLAMA_1B_PARAMS

--- a/entropix/torch_main.py
+++ b/entropix/torch_main.py
@@ -1,19 +1,15 @@
-from typing import NamedTuple, Optional, Tuple
-
 import torch
-import torch.nn.functional as F
 
-import math
+
 import tyro
 
 from pathlib import Path
-from functools import partial
 
 from entropix.config import LLAMA_1B_PARAMS
 from entropix.tokenizer import Tokenizer
 from entropix.torch_kvcache import KVCache
 from entropix.torch_model import xfmr
-from entropix.torch_weights import XfmrWeights, LayerWeights, load_weights
+from entropix.torch_weights import load_weights
 from entropix.torch_sampler import sample
 from entropix.prompts import create_prompts_from_csv, prompt, bp1
 
@@ -117,14 +113,14 @@ def main():
         if torch.isin(next_token, stop).any():
           break
 
-    csv_path = Path('entropix/prompts.csv')
+    csv_path = Path('entropix/data/prompts.csv')
     prompts = create_prompts_from_csv(csv_path)
     PROMPT_TEST = False
 
     if PROMPT_TEST:
-      for prompt in prompts:
-        print(prompt)
-        tokens = tokenizer.encode(prompt, bos=False, eos=False, allowed_special='all')
+      for test_prompt in prompts:
+        print(test_prompt)
+        tokens = tokenizer.encode(test_prompt, bos=False, eos=False, allowed_special='all')
         generate(xfmr_weights, model_params, tokens)
     else:
         raw_tokens1 = tokenizer.encode(prompt,  bos=False, eos=False, allowed_special='all')

--- a/entropix/torch_model.py
+++ b/entropix/torch_model.py
@@ -54,7 +54,7 @@ def attention(x: torch.Tensor, layer_weights: LayerWeights, model_params, cur_po
         scores = scores + attn_mask
     mask = torch.where(scores != 0.0, scores, DEFAULT_MASK_VALUE)
     padded_logits = torch.where((mask >= DEFAULT_MASK_VALUE * 0.5), scores, DEFAULT_MASK_VALUE)
-    scores = F.softmax(padded_logits, dim=-1).to(torch.float32)
+    scores = F.softmax(padded_logits, dim=-1).to(x.dtype)
     output = torch.matmul(scores, values)
     output = output.transpose(1, 2).reshape(xq.shape[0], xq.shape[2], -1)
     out = F.linear(output, layer_weights.wo)

--- a/entropix/torch_sampler.py
+++ b/entropix/torch_sampler.py
@@ -55,7 +55,7 @@ def calculate_metrics(logits: torch.Tensor, attention_scores: torch.Tensor) -> D
     entropy, varentropy = calculate_varentropy_logsoftmax(logits)
     attention_probs = F.softmax(attention_scores, dim=-1)
     attn_entropy = -torch.sum(attention_probs * torch.log2(torch.clamp(attention_probs, 1e-10, 1.0)), dim=-1)
-    attn_varentropy = torch.var(attn_entropy, dim=-1)
+    attn_varentropy = torch.var(attn_entropy, dim=1)
     
     # Add a small epsilon to avoid NaN when all values are the same
     attn_varentropy = torch.where(torch.isnan(attn_varentropy), torch.zeros_like(attn_varentropy), attn_varentropy)


### PR DESCRIPTION
This PR does the following:
1) Bugfixes the conflicting torch dtypes in the attention computation by casting the returned key and values from the kv cache to the input types. This matches the JAX implementation where key, values are stored in fp32 and fp16 respectively post ROPE. (thanks @tensorqt for bringing this up) (should also close #50)

2) qol fixes surrounding `torch_main.py` cleaning up imports and setting up prompt testing similar to `main.py`

3) Fixes changes from #17 being overwritten 